### PR TITLE
Add DevMeme under Websites

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ The goal is to build a categorized, community-driven collection of high-quality 
 ## Websites
 
 * [aiweirdness](http://aiweirdness.com/) - Unintentional humor as machine learning algorithms struggle to imitate human datasets.
+* [DevMeme](https://devme.me) - Searchable library of programming memes — type the concept ("race condition", "LGTM", "on-call") and land on the joke instead of scrolling forever.
 * [motherfuckingwebsite](https://motherfuckingwebsite.com/)
     * [bettermotherfuckingwebsite](http://bettermotherfuckingwebsite.com/)
     * [thebestmotherfucking](https://thebestmotherfucking.website/)


### PR DESCRIPTION
## Why this belongs in **awesome-programming-humor**

Your README frames the list as:

> *A collection of awesome software, subreddits, websites, and other cool stuff that **programmers would find funny**… a categorized, community-driven collection of **high-quality computer science/programming humor**.*

**Websites** right now is almost all *single-concept joke sites* (aiweirdness, shouldiblamecaching, the motherfuckingwebsite family, Unicorn Valley). That voice is great — short, sharp, CS-native.

**DevMeme** is programming humor too, but of a different shape: a **catalog of developer/DevOps memes you can full-text search by concept**. Same audience, different job: not “load the page and laugh once,” but “I need *the* meme for this exact pain right now.”

### How it matches the list’s bar

| List goal | How DevMeme hits it |
|---|---|
| Programmers find it funny | ~7k programming / engineering / on-call / PR / AI-hype memes |
| High-quality CS/programming humor | Curated catalog + categories/tags (not a random image firehose) |
| “Cool stuff” programmers use | **Full-text contextual search** — titles, tags, categories, joke/context text |
| Fits **Websites** | Public site: https://devme.me |

Existing **Subreddits** already cover r/ProgrammerHumor etc. DevMeme is the *website* you go to when you want that humor **as a searchable library** instead of another feed.

### Entry (alpha under Websites)

Placed after `aiweirdness`, before `motherfuckingwebsite` (alphabetical).

```markdown
* [DevMeme](https://devme.me) - Searchable library of programming memes — type the concept ("race condition", "LGTM", "on-call") and land on the joke instead of scrolling forever.
```

Format follows CONTRIBUTING: useful PR title, individual suggestion, `[Item Name](link)`, title-casing, alpha in section.

Happy to shorten the blurb if you want it even drier like `shouldiblamecaching`. Thanks for maintaining the list.